### PR TITLE
fix ruff FURB110 lint violation in get_screening_df

### DIFF
--- a/src/meta_analytics/dataframes/screening/get_screening_df.py
+++ b/src/meta_analytics/dataframes/screening/get_screening_df.py
@@ -72,7 +72,7 @@ def get_screening_df(df: pd.DataFrame | None = None) -> pd.DataFrame:
     # condition to include any glucose test
 
     # has_dm fillna with unk
-    df["has_dm"] = df["has_dm"].apply(lambda x: x if x else "unk")
+    df["has_dm"] = df["has_dm"].apply(lambda x: x or "unk")
 
     na = "Not applicable, subject is not eligible based on the criteria above"
     df["already_fasted"] = df["already_fasted"].apply(lambda x: "N/A" if x == na else x)


### PR DESCRIPTION
Replace ternary `if` expression with `or` operator.