### PR TITLE
Swap pdfkit/wkhtmltopdf for WeasyPrint in monitoring report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,19 @@ dependencies = [
     "Django>=5.2,<6.1",
     "celery>=5.6.2",
     "clinicedc==3.1.5",
+    "django-pandas>=0.6.7",
     "edc-he>=2.1.0",
     "edc-microscopy>=2.0.0",
     "edc-mnsi>=2.0.0",
     "edc-phq9>=2.0.0",
     "edc-qol>=2.0.0",
-    "notebook>=7.4.7",
+    "great-tables>=0.21.0",
+    "matplotlib>=3.10.8",
+    "numpy>=2.4.4",
     "openpyxl>=3.1.5",
+    "pandas>=3.0.2",
+    "scipy>=1.17.1",
+    "weasyprint>=62.0",
 ]
 
 [build-system]
@@ -77,7 +83,7 @@ namespace = false
 [tool.ruff]
 line-length = 95
 indent-width = 4
-target-version = "py313"
+target-version = "py312"
 extend-exclude = [
     "migrations",
     "*/view_definition.py",
@@ -139,10 +145,10 @@ exclude = ["*.ipynb"]
 [tool.coverage.run]
 parallel = false
 branch = true
-source = ["meta_edc"]
+source = ["src"]
 
 [tool.coverage.paths]
-source = ["meta_edc"]
+source = ["src"]
 
 [tool.coverage.report]
 show_missing = true
@@ -171,18 +177,12 @@ dev = [
     "dj-notebook>=0.7.0",
     "django-webtest>=1.9.14",
     "edc-test-settings>=2.1.0",
-    "great-tables>=0.18.0",
     "ipython>=9.7.0",
     "matplotlib-venn>=1.1.2",
-    "matplotlib>=3.10.3",
     "notebook>=7.4.7",
-    "numpy>=2.3.2",
-    "pandas>=2.3.1",
-    "pdfkit>=1.0.0",
     "remote-read-sql>=1.2.3",
     "scikit-learn>=1.7.1",
     "scipy-stubs~=1.16.3",
-    "scipy>=1.16.0",
     "seaborn>=0.13.2",
     "selenium>=4.34.2",
     "statsmodels>=0.14.5",
@@ -191,6 +191,9 @@ dev = [
     "tox>=4.32.0",
     "xlrd>=2.0.2",
 ]
+
+[tool.uv]
+override-dependencies = ["bleach>=6.0"]
 
 [tool.uv.sources]
 meta-edc = { workspace = true }

--- a/src/meta_analytics/monitoring_report.py
+++ b/src/meta_analytics/monitoring_report.py
@@ -8,6 +8,25 @@ the full pipeline of ~15 tables and writes a PDF to the given path.
 
 The management command ``generate_monitoring_report`` is a thin wrapper
 around this function.
+
+WeasyPrint system library requirements
+--------------------------------------
+WeasyPrint (>=53) is a pure-Python renderer but links to system libraries
+via ctypes. Install them before running the report:
+
+Ubuntu / Debian (24.04 verified)::
+
+    sudo apt install -y libpango-1.0-0 libpangoft2-1.0-0
+
+macOS (Homebrew)::
+
+    brew install pango
+
+On Apple Silicon, if WeasyPrint cannot find the libs, export::
+
+    export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH
+
+Cairo and GDK-Pixbuf are *not* required by WeasyPrint 53+.
 """
 
 from __future__ import annotations
@@ -19,7 +38,6 @@ from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
-import pdfkit
 from clinicedc_constants import YES
 from django_pandas.io import read_frame
 from edc_appointment.analytics import get_appointment_df
@@ -35,6 +53,7 @@ from edc_pdutils.dataframes import get_subject_visit
 from edc_visit_schedule.models import SubjectScheduleHistory
 from great_tables import html, loc, md, style
 from scipy.stats import chi2
+from weasyprint import HTML
 
 from meta_analytics.dataframes import (
     GlucoseEndpointsByDate2,
@@ -1433,45 +1452,44 @@ def generate_monitoring_report(
 
     # --- assemble and render PDF --------------------------------------------
     raw_html = [f'<div class="page-break">{s}</div>' for s in html_data]
-    style_css = """
+    # WeasyPrint uses @page rules for margins, headers and footers.
+    # Study title in @top-center (escape double quotes for CSS string).
+    study_title_css = study_title.replace('"', '\\"')
+    style_css = f"""
 <style>
-  .page-break {
+  @page {{
+    size: A4;
+    margin: 15mm 15mm 15mm 15mm;
+    @top-center {{
+      content: "{study_title_css}";
+      font-size: 8pt;
+    }}
+    @bottom-center {{
+      content: "Page " counter(page) " of " counter(pages);
+      font-size: 8pt;
+    }}
+  }}
+  .page-break {{
     page-break-inside: avoid;
-  }
-  .table-header {
+  }}
+  .table-header {{
     font-weight: bold;
     font-size: 18px;
     text-align: center;
-    border-bottom: None;
-  }
+    border-bottom: none;
+  }}
 </style>
 """
     raw_html_str = (
-        f'<!DOCTYPE html>\n<html lang="en">\n{style_css}\n<head>\n'
-        '<meta charset="utf-8"/>\n</head>\n<body>\n'
+        f'<!DOCTYPE html>\n<html lang="en">\n<head>\n'
+        '<meta charset="utf-8"/>\n'
+        f"{style_css}\n</head>\n<body>\n"
         + document_title
         + "".join(raw_html)
         + "\n</body>\n</html>\n"
     )
 
-    pdfkit.from_string(
-        raw_html_str,
-        str(output_path),
-        options={
-            "footer-center": "Page [page] of [topage]",
-            "footer-font-size": "8",
-            "footer-spacing": "5",
-            "encoding": "UTF-8",
-            "margin-top": "10mm",
-            "margin-right": "15mm",
-            "margin-bottom": "15mm",
-            "margin-left": "15mm",
-            "header-center": study_title,
-            "header-font-size": "6",
-            "header-spacing": "0",
-            "disable-javascript": None,
-            "no-outline": None,
-        },
-        verbose=verbose,
-    )
+    # WeasyPrint has no "verbose" option; the flag is accepted for API parity.
+    _ = verbose
+    HTML(string=raw_html_str).write_pdf(str(output_path))
     return output_path

--- a/src/meta_reports/management/commands/generate_monitoring_report.py
+++ b/src/meta_reports/management/commands/generate_monitoring_report.py
@@ -93,28 +93,28 @@ class Command(BaseCommand):
         if not end_of_trial_date:
             end_of_trial_date = settings.END_OF_TRAIL_DATETIME
 
-            effective_cutoff = cutoff_date or datetime.now(tz=ZoneInfo("UTC")).replace(
-                hour=23, minute=59, second=0, microsecond=0
-            )
-            filename = f"monitoring_report_{effective_cutoff.strftime('%Y%m%d')}.pdf"
+        effective_cutoff = cutoff_date or datetime.now(tz=ZoneInfo("UTC")).replace(
+            hour=23, minute=59, second=0, microsecond=0
+        )
+        filename = f"monitoring_report_{effective_cutoff.strftime('%Y%m%d')}.pdf"
 
-            output_raw = options["output"]
-            if output_raw:
-                output_path = Path(output_raw).expanduser()
+        output_raw = options["output"]
+        if output_raw:
+            output_path = Path(output_raw).expanduser()
             if output_path.is_dir() or output_raw.endswith(os.sep):
                 output_path = output_path / filename
-            elif os.environ.get("META_ANALYSIS_FOLDER"):
-                output_path = Path(os.environ["META_ANALYSIS_FOLDER"]).expanduser() / filename
-            else:
-                output_path = Path.cwd() / filename
+        elif os.environ.get("META_ANALYSIS_FOLDER"):
+            output_path = Path(os.environ["META_ANALYSIS_FOLDER"]).expanduser() / filename
+        else:
+            output_path = Path.cwd() / filename
 
-            self.stdout.write(f"Generating monitoring report -> {output_path}")
-            result = generate_monitoring_report(
-                output_path=output_path,
-                cutoff_date=cutoff_date,
-                data_download_date=data_download_date,
-                end_of_trial_date=end_of_trial_date,
-                verbose=options["verbose_pdf"],
-            )
-            self.stdout.write(self.style.SUCCESS(f"Wrote {result}"))
-            sys.stdout.flush()
+        self.stdout.write(f"Generating monitoring report -> {output_path}")
+        result = generate_monitoring_report(
+            output_path=output_path,
+            cutoff_date=cutoff_date,
+            data_download_date=data_download_date,
+            end_of_trial_date=end_of_trial_date,
+            verbose=options["verbose_pdf"],
+        )
+        self.stdout.write(self.style.SUCCESS(f"Wrote {result}"))
+        sys.stdout.flush()


### PR DESCRIPTION
wkhtmltopdf is unmaintained (upstream archived 2023) and missing on the
Ubuntu live server. WeasyPrint is pure-Python with widely-available
system libs (Pango). Also promotes the analytics runtime deps (pandas,
numpy, scipy, great-tables, matplotlib, django-pandas) from the dev
group to main deps so the management command runs without `--group dev`.

- monitoring_report.py: use weasyprint.HTML; move header/footer/margins
  into @page CSS rules; document Ubuntu/macOS system-lib install.
- pyproject.toml: drop pdfkit, add weasyprint>=62.0; move analytics
  deps to main; remove duplicate `notebook`; align ruff target-version
  with requires-python floor (py312); fix coverage source to `src`;
  add uv override for bleach>=6.0 to avoid nbconvert downgrade.
- generate_monitoring_report command: fix indentation bug so output
  path resolution runs unconditionally (previously gated on the
  END_OF_TRAIL_DATETIME fallback branch).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
